### PR TITLE
Fix python.django.security.audit.django-rest-framework.missing-throttle-config.missing-throttle-config--tmp-7b165fbc-5235-4250-ac45-5f7061608bfe-backend-backend-settings-base.py

### DIFF
--- a/backend/backend/settings/base.py
+++ b/backend/backend/settings/base.py
@@ -418,6 +418,15 @@ STATIC_ROOT = os.path.join(BASE_DIR, "static")
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 REST_FRAMEWORK = {
+    # Rate limiting configuration to prevent DoS attacks
+    'DEFAULT_THROTTLE_CLASSES': [
+        'rest_framework.throttling.AnonRateThrottle',
+        'rest_framework.throttling.UserRateThrottle',
+    ],
+    'DEFAULT_THROTTLE_RATES': {
+        'anon': '100/day',
+        'user': '1000/day',
+    },
     "DEFAULT_RENDERER_CLASSES": [
         "rest_framework.renderers.JSONRenderer",
     ],


### PR DESCRIPTION
This PR fixes python.django.security.audit.django-rest-framework.missing-throttle-config.missing-throttle-config--tmp-7b165fbc-5235-4250-ac45-5f7061608bfe-backend-backend-settings-base.py.