### PR TITLE
Fix yaml.docker-compose.security.no-new-privileges.no-new-privileges--tmp-7b165fbc-5235-4250-ac45-5f7061608bfe-docker-connector-docker-compose-connector.yaml

### DIFF
--- a/docker/connector/docker-compose-connector.yaml
+++ b/docker/connector/docker-compose-connector.yaml
@@ -2,6 +2,8 @@ version: '3.7'
 
 services:
   mariadb:
+    security_opt:
+      - no-new-privileges:true
     image: 'mariadb:11.2.4'
     container_name: unstract-mariadb
     ports:


### PR DESCRIPTION
This PR fixes yaml.docker-compose.security.no-new-privileges.no-new-privileges--tmp-7b165fbc-5235-4250-ac45-5f7061608bfe-docker-connector-docker-compose-connector.yaml.