### PR TITLE
Fix yaml.docker-compose.security.writable-filesystem-service.writable-filesystem-service--tmp-7b165fbc-5235-4250-ac45-5f7061608bfe-docker-connector-docker-compose-connector.yaml

### DIFF
--- a/docker/connector/docker-compose-connector.yaml
+++ b/docker/connector/docker-compose-connector.yaml
@@ -2,7 +2,17 @@ version: '3.7'
 
 services:
   mariadb:
+    tmpfs:
+      - /tmp
+      - /var/tmp
+      - /run
+    read_only: true
     image: 'mariadb:11.2.4'
+    tmpfs:
+      - /tmp
+      - /var/tmp
+      - /run
+    read_only: true
     container_name: unstract-mariadb
     ports:
       - "3306:3306"


### PR DESCRIPTION
This PR fixes yaml.docker-compose.security.writable-filesystem-service.writable-filesystem-service--tmp-7b165fbc-5235-4250-ac45-5f7061608bfe-docker-connector-docker-compose-connector.yaml.