### PR TITLE
Fix yaml.docker-compose.security.no-new-privileges.no-new-privileges--tmp-7b165fbc-5235-4250-ac45-5f7061608bfe-docker-connector-docker-compose-connector.yaml

### DIFF
--- a/docker/connector/docker-compose-connector.yaml
+++ b/docker/connector/docker-compose-connector.yaml
@@ -12,7 +12,11 @@ services:
       - .env
 
   mysql:
+    security_opt:
+      - no-new-privileges:true
     image: 'mysql:9.0.1'
+    security_opt:
+      - no-new-privileges:true
     container_name: unstract-mysql
     env_file:
       - .env


### PR DESCRIPTION
This PR fixes yaml.docker-compose.security.no-new-privileges.no-new-privileges--tmp-7b165fbc-5235-4250-ac45-5f7061608bfe-docker-connector-docker-compose-connector.yaml.