### PR TITLE
Fix yaml.docker-compose.security.writable-filesystem-service.writable-filesystem-service--tmp-7b165fbc-5235-4250-ac45-5f7061608bfe-docker-connector-docker-compose-connector.yaml

### DIFF
--- a/docker/connector/docker-compose-connector.yaml
+++ b/docker/connector/docker-compose-connector.yaml
@@ -13,13 +13,21 @@ services:
 
   mysql:
     image: 'mysql:9.0.1'
+    read_only: true
     container_name: unstract-mysql
+    read_only: true
     env_file:
+    read_only: true
       - .env
+    read_only: true
     ports:
+    read_only: true
       - "3307:3306"
+    read_only: true
     volumes:
+    read_only: true
       - mysql_data:/var/lib/mysql
+    read_only: true
 
   mssql:
     image: mcr.microsoft.com/mssql/server:2022-preview-ubuntu-22.04


### PR DESCRIPTION
This PR fixes yaml.docker-compose.security.writable-filesystem-service.writable-filesystem-service--tmp-7b165fbc-5235-4250-ac45-5f7061608bfe-docker-connector-docker-compose-connector.yaml.