### PR TITLE
Fix yaml.docker-compose.security.writable-filesystem-service.writable-filesystem-service--tmp-7b165fbc-5235-4250-ac45-5f7061608bfe-docker-connector-docker-compose-connector.yaml

### DIFF
--- a/docker/connector/docker-compose-connector.yaml
+++ b/docker/connector/docker-compose-connector.yaml
@@ -23,13 +23,21 @@ services:
 
   mssql:
     image: mcr.microsoft.com/mssql/server:2022-preview-ubuntu-22.04
+    read_only: true
     container_name: unstract-mssql
+    read_only: true
     env_file:
+    read_only: true
       - .env
+    read_only: true
     ports:
+    read_only: true
       - "1433:1433"
+    read_only: true
     volumes:
+    read_only: true
       - mssql_data:/var/opt/mssql
+    read_only: true
 
   sftp:
     image: atmoz/sftp:debian


### PR DESCRIPTION
This PR fixes yaml.docker-compose.security.writable-filesystem-service.writable-filesystem-service--tmp-7b165fbc-5235-4250-ac45-5f7061608bfe-docker-connector-docker-compose-connector.yaml.