### PR TITLE
Fix yaml.docker-compose.security.writable-filesystem-service.writable-filesystem-service--tmp-7b165fbc-5235-4250-ac45-5f7061608bfe-docker-connector-docker-compose-connector.yaml

### DIFF
--- a/docker/connector/docker-compose-connector.yaml
+++ b/docker/connector/docker-compose-connector.yaml
@@ -33,11 +33,17 @@ services:
 
   sftp:
     image: atmoz/sftp:debian
+    read_only: true
     ports:
+    read_only: true
       - "22:22"
+    read_only: true
     volumes:
+    read_only: true
       - sftp_data:/home/foo
+    read_only: true
     command: "${SFTP_USER}:${SFTP_PASS}:${SFTP_USER_ID}::${SFTP_DIR}"
+    read_only: true
 
 volumes:
   mariadb_data:


### PR DESCRIPTION
This PR fixes yaml.docker-compose.security.writable-filesystem-service.writable-filesystem-service--tmp-7b165fbc-5235-4250-ac45-5f7061608bfe-docker-connector-docker-compose-connector.yaml.