### PR TITLE
Fix python.lang.security.audit.eval-detected.eval-detected--tmp-7b165fbc-5235-4250-ac45-5f7061608bfe-unstract-connectors-src-unstract-connectors-databases-exceptions_helper.py

### DIFF
--- a/unstract/connectors/src/unstract/connectors/databases/exceptions_helper.py
+++ b/unstract/connectors/src/unstract/connectors/databases/exceptions_helper.py
@@ -1,3 +1,4 @@
+import ast
 from typing import Any
 
 
@@ -14,7 +15,7 @@ class ExceptionHelper:
             Any: _description_
         """
         error_message = str(e)
-        error_code, error_details = eval(error_message)
+        error_code, error_details = ast.literal_eval(error_message)
         if isinstance(error_details, bytes):
             error_details = error_details.decode("utf-8")
         return error_details


### PR DESCRIPTION
This PR fixes python.lang.security.audit.eval-detected.eval-detected--tmp-7b165fbc-5235-4250-ac45-5f7061608bfe-unstract-connectors-src-unstract-connectors-databases-exceptions_helper.py.