### PR TITLE
Fix dockerfile.security.missing-user-entrypoint.missing-user-entrypoint--tmp-7b165fbc-5235-4250-ac45-5f7061608bfe-tools-text_extractor-Dockerfile

### DIFF
--- a/tools/text_extractor/Dockerfile
+++ b/tools/text_extractor/Dockerfile
@@ -24,3 +24,11 @@ WORKDIR /app/src
 
 
 ENTRYPOINT ["opentelemetry-instrument", "python", "main.py"]
+# Create a non-root user and set proper permissions
+RUN groupadd -r appuser && useradd -r -g appuser appuser
+
+# Set permissions for application files
+RUN chown -R appuser:appuser /app
+
+# Switch to non-root user
+USER appuser


### PR DESCRIPTION
This PR fixes dockerfile.security.missing-user-entrypoint.missing-user-entrypoint--tmp-7b165fbc-5235-4250-ac45-5f7061608bfe-tools-text_extractor-Dockerfile.